### PR TITLE
Fix 'shape' referenced before assignment issue

### DIFF
--- a/maya/scripts/shaderManager/shaderManager.py
+++ b/maya/scripts/shaderManager/shaderManager.py
@@ -1052,11 +1052,10 @@ class ShaderManager(QMainWindow, UI_ABCHierarchy.Ui_NAM):
                 shape = x
             else:
                 shapes = cmds.listRelatives(x, shapes=True, f=1)
-                if shapes:
-                    shape = shapes[0]
+                if not shapes:
+                    continue
+                shape = shapes[0]
             if cmds.nodeType(shape) == "gpuCache" or cmds.nodeType(shape) == "alembicHolder":
-
-
 
                 self.ABCViewerNode[shape] = gpucache.gpucache(shape, self)
                 cacheAssignations = self.ABCViewerNode[shape].getAssignations()


### PR DESCRIPTION
This crops up when a transform is selected with no underlying shape (ie. a group node).

That is, creating an empty group and selecting it:
```
cmds.select(cmds.createNode("transform"))
```
then opening the cache manager triggers an error. "shape" is an undefined variable. Skipping this transform when looping over the selected items resolves this issue.